### PR TITLE
Add an option to use docstring instead of revision hash

### DIFF
--- a/alembic_viz/alembic_viz.py
+++ b/alembic_viz/alembic_viz.py
@@ -4,8 +4,8 @@ from alembic.config import Config
 from alembic.util import CommandError
 import click
 
-from .utils import get_revisions
-from .utils import generate_revision_graph
+from utils import get_revisions
+from utils import generate_revision_graph
 
 VALID_OUTPUT_FORMATS = ['png', 'svg', 'pdf']
 
@@ -15,7 +15,7 @@ VALID_OUTPUT_FORMATS = ['png', 'svg', 'pdf']
 @click.option('--filename', default='migrations', help='output file name without file extension')
 @click.option('--format', default='png', help='output file format',
               type=click.Choice(VALID_OUTPUT_FORMATS))
-@click.option('--enable-desc', default='no', help='enable description of commits',
+@click.option('--enable-desc', default='yes', help='enable description of commits',
               type=click.Choice(['yes', 'no']))
 def cli(config, name, filename, format, enable_desc):
     alembic_config = Config(file_=config, ini_section=name)

--- a/alembic_viz/alembic_viz.py
+++ b/alembic_viz/alembic_viz.py
@@ -15,13 +15,15 @@ VALID_OUTPUT_FORMATS = ['png', 'svg', 'pdf']
 @click.option('--filename', default='migrations', help='output file name without file extension')
 @click.option('--format', default='png', help='output file format',
               type=click.Choice(VALID_OUTPUT_FORMATS))
-def cli(config, name, filename, format):
+@click.option('--enable-desc', default='no', help='enable description of commits',
+              type=click.Choice(['yes', 'no']))
+def cli(config, name, filename, format, enable_desc):
     alembic_config = Config(file_=config, ini_section=name)
     try:
         revisions = get_revisions(alembic_config)
     except CommandError as e:
         sys.exit(e)
-    dot = generate_revision_graph(revisions, format)
+    dot = generate_revision_graph(revisions, format, enable_desc)
     dot.render(filename=filename)
 
 

--- a/alembic_viz/utils.py
+++ b/alembic_viz/utils.py
@@ -19,10 +19,13 @@ def get_revisions(config, rev_range=None):
     )
 
 
-def generate_revision_graph(revisions, format):
+def generate_revision_graph(revisions, format, enable_desc):
     dot = Digraph(format='png')
     for revision in revisions:
-        dot.node(revision.revision)
+        if enable_desc == "yes":
+            dot.node(revision.revision, revision.doc)
+        else:
+            dot.node(revision.revision)
         if revision.down_revision is None:
             dot.edge('base', revision.revision)
             continue

--- a/alembic_viz/utils.py
+++ b/alembic_viz/utils.py
@@ -23,7 +23,7 @@ def generate_revision_graph(revisions, format, enable_desc):
     dot = Digraph(format='png')
     for revision in revisions:
         if enable_desc == "yes":
-            dot.node(revision.revision, revision.doc)
+            dot.node(revision.revision, "<<B>" + revision.revision + "</B><br />" + revision.doc + ">")
         else:
             dot.node(revision.revision)
         if revision.down_revision is None:


### PR DESCRIPTION
Hi @javaes,

I have just modified your script for my own usage and I wondered if you'd be interested. I just added an option to be able to use docstring instead of rev as rev are not always very talkative...

Would be happy to help if I could on this